### PR TITLE
Update module path & goreleaser to reflect new Github Org

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,7 @@ before:
 builds:
   - id: svix
     ldflags:
-      - -s -w -X github.com/svixhq/svix-cli/version.Version={{ .Version }}
+      - -s -w -X github.com/svix/svix-cli/version.Version={{ .Version }}
     env:
       - CGO_ENABLED=0
     goos:
@@ -38,7 +38,7 @@ nfpms:
       - apk
 brews:
   - tap:
-      owner: svixhq
+      owner: svix
       name: homebrew-svix
     commit_author:
       name: svix-ci
@@ -50,7 +50,7 @@ brews:
     caveats: "Thanks for installing the Svix CLI! If this is your first time using the CLI, checkout our docs at https://docs.svix.com."
 scoop:
   bucket:
-    owner: svixhq
+    owner: svix
     name: scoop-svix
   commit_author:
     name: svix-ci

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A CLI to interact with the Svix API.
 The Svix CLI is available on macOS via [Homebrew](https://brew.sh/):
 
 ```sh
-brew install svixhq/svix/svix
+brew install svix/svix/svix
 ```
 
 ### Windows
@@ -27,7 +27,7 @@ brew install svixhq/svix/svix
 The Svix CLI is available on Windows via the [Scoop](https://scoop.sh/) package manager:
 
 ```sh
-scoop bucket add svix https://github.com/svixhq/scoop-svix.git
+scoop bucket add svix https://github.com/svix/scoop-svix.git
 scoop install svix
 ```
 
@@ -117,9 +117,9 @@ This project uses [goreleaser](https://github.com/goreleaser/goreleaser/).
  2) Install goreleaser via the steps [here](https://goreleaser.com/install/).
  3) Build current commit via `goreleaser release --snapshot --skip-publish`.
 
-[release-img]: https://img.shields.io/github/v/release/svixhq/svix-cli
-[release]: https://github.com/svixhq/svix-cli/releases
-[golangci-lint-img]: https://github.com/svixhq/svix-cli/workflows/go-lint/badge.svg
-[golangci-lint]: https://github.com/svixhq/svix-cli/actions?query=workflow%3Ago-lint
-[report-card-img]: https://goreportcard.com/badge/github.com/svixhq/svix-cli
-[report-card]: https://goreportcard.com/report/github.com/svixhq/svix-cli
+[release-img]: https://img.shields.io/github/v/release/svix/svix-cli
+[release]: https://github.com/svix/svix-cli/releases
+[golangci-lint-img]: https://github.com/svix/svix-cli/workflows/go-lint/badge.svg
+[golangci-lint]: https://github.com/svix/svix-cli/actions?query=workflow%3Ago-lint
+[report-card-img]: https://goreportcard.com/badge/github.com/svix/svix-cli
+[report-card]: https://goreportcard.com/report/github.com/svix/svix-cli

--- a/cmd/application.go
+++ b/cmd/application.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/svixhq/svix-cli/pretty"
-	"github.com/svixhq/svix-cli/utils"
-	"github.com/svixhq/svix-cli/validators"
+	"github.com/svix/svix-cli/pretty"
+	"github.com/svix/svix-cli/utils"
+	"github.com/svix/svix-cli/validators"
 	svix "github.com/svixhq/svix-libs/go"
 )
 

--- a/cmd/authentication.go
+++ b/cmd/authentication.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/svixhq/svix-cli/pretty"
-	"github.com/svixhq/svix-cli/validators"
+	"github.com/svix/svix-cli/pretty"
+	"github.com/svix/svix-cli/validators"
 )
 
 type authenticationCmd struct {

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -4,7 +4,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/svixhq/svix-cli/validators"
+	"github.com/svix/svix-cli/validators"
 )
 
 type completionCmd struct {

--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/svixhq/svix-cli/pretty"
-	"github.com/svixhq/svix-cli/utils"
-	"github.com/svixhq/svix-cli/validators"
+	"github.com/svix/svix-cli/pretty"
+	"github.com/svix/svix-cli/utils"
+	"github.com/svix/svix-cli/validators"
 	svix "github.com/svixhq/svix-libs/go"
 )
 

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/svixhq/svix-cli/pretty"
-	"github.com/svixhq/svix-cli/utils"
-	"github.com/svixhq/svix-cli/validators"
+	"github.com/svix/svix-cli/pretty"
+	"github.com/svix/svix-cli/utils"
+	"github.com/svix/svix-cli/validators"
 	svix "github.com/svixhq/svix-libs/go"
 )
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/svixhq/svix-cli/pretty"
+	"github.com/svix/svix-cli/pretty"
 	svix "github.com/svixhq/svix-libs/go"
 )
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -7,8 +7,8 @@ import (
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/svixhq/svix-cli/config"
-	"github.com/svixhq/svix-cli/validators"
+	"github.com/svix/svix-cli/config"
+	"github.com/svix/svix-cli/validators"
 )
 
 type loginCmd struct {

--- a/cmd/message.go
+++ b/cmd/message.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/svixhq/svix-cli/pretty"
-	"github.com/svixhq/svix-cli/utils"
-	"github.com/svixhq/svix-cli/validators"
+	"github.com/svix/svix-cli/pretty"
+	"github.com/svix/svix-cli/utils"
+	"github.com/svix/svix-cli/validators"
 	svix "github.com/svixhq/svix-libs/go"
 )
 

--- a/cmd/messageattempt.go
+++ b/cmd/messageattempt.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/svixhq/svix-cli/pretty"
-	"github.com/svixhq/svix-cli/validators"
+	"github.com/svix/svix-cli/pretty"
+	"github.com/svix/svix-cli/validators"
 )
 
 type messageAttemptCmd struct {

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/skratchdot/open-golang/open"
 	"github.com/spf13/cobra"
-	"github.com/svixhq/svix-cli/pretty"
-	"github.com/svixhq/svix-cli/validators"
+	"github.com/svix/svix-cli/pretty"
+	"github.com/svix/svix-cli/validators"
 )
 
 var openableURLs = map[string]string{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,9 +9,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/svixhq/svix-cli/config"
-	"github.com/svixhq/svix-cli/utils"
-	"github.com/svixhq/svix-cli/version"
+	"github.com/svix/svix-cli/config"
+	"github.com/svix/svix-cli/utils"
+	"github.com/svix/svix-cli/version"
 	svix "github.com/svixhq/svix-libs/go"
 )
 

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/svixhq/svix-cli/utils"
-	"github.com/svixhq/svix-cli/validators"
+	"github.com/svix/svix-cli/utils"
+	"github.com/svix/svix-cli/validators"
 	svix "github.com/svixhq/svix-libs/go"
 )
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/svixhq/svix-cli/validators"
-	"github.com/svixhq/svix-cli/version"
+	"github.com/svix/svix-cli/validators"
+	"github.com/svix/svix-cli/version"
 )
 
 type versionCmd struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/svixhq/svix-cli
+module github.com/svix/svix-cli
 
 go 1.16
 

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,6 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/svixhq/svix-libs v0.14.1-0.20210531145855-ff10b4b07c16 h1:7gwjY8u0JTYYmGtQjl98BlCj4us1X0yYZKoTQqOubaU=
-github.com/svixhq/svix-libs v0.14.1-0.20210531145855-ff10b4b07c16/go.mod h1:kEftBTj5YbYjBeI4jjsXss3yrE+u0bH2seuEu2RoJ08=
 github.com/svixhq/svix-libs v0.16.0 h1:pmJ8CE7erlmCvPO0msUcMncOZidzHYojEXeWscIvbC0=
 github.com/svixhq/svix-libs v0.16.0/go.mod h1:kEftBTj5YbYjBeI4jjsXss3yrE+u0bH2seuEu2RoJ08=
 github.com/tidwall/pretty v1.1.1 h1:nt6/Ot5LtZnJCWwEFlelOixPo0xhPFsuZlKyOL3Xfnc=

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/svixhq/svix-cli/cmd"
+import "github.com/svix/svix-cli/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
Still depending on `github.com/svixhq/svix-libs` pending the next release of our libraries