### PR TITLE
Update readme's local dev build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ For a more information, checkout our [API reference](https://docs.svix.com).
 This project uses [goreleaser](https://github.com/goreleaser/goreleaser/).
  1) Install [go](https://golang.org/doc/install).
  2) Install goreleaser via the steps [here](https://goreleaser.com/install/).
- 3) Build current commit via `goreleaser release --snapshot --skip-publish`.
+ 3) Build current commit via `goreleaser release --snapshot --skip-publish --rm-dist`.
 
 [release-img]: https://img.shields.io/github/v/release/svixhq/svix-cli
 [release]: https://github.com/svixhq/svix-cli/releases


### PR DESCRIPTION
There's no reason to preserve the dist folder when testing locally, this updates the oneliner to automatically clear out old builds so you can run the same command consecutively when testing changes.