### PR TITLE
Verify: print non-timestamp-enforced error if found

### DIFF
--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -82,7 +82,7 @@ func newVerifyCmd() *verifyCmd {
 					fmt.Println("Signature is valid but failed timestamp verification.")
 					os.Exit(1)
 				}
-				printer.CheckErr(err)
+				printer.CheckErr(errNoTimestamp)
 			}
 			fmt.Println("Message Signature Is Valid!")
 		},


### PR DESCRIPTION
Should result in clearer error messages if both timestamp & signature is invalid.