### PR TITLE
Attempt fixing error in Svix Play listen mode

### DIFF
--- a/relay/relay.go
+++ b/relay/relay.go
@@ -130,11 +130,11 @@ func (c *Client) Listen(ctx context.Context) {
 			close(c.stopRead)
 			close(c.stopWrite)
 
+			c.wg.Wait()
+
 			if c.conn != nil {
 				c.conn.Close()
 			}
-
-			c.wg.Wait()
 		}
 	}
 }


### PR DESCRIPTION
On occasion the listen command would fail to reconnect to the Play server and instead hang. This change attempts to fix that by making sure the socket read and write tasks shutdown before the connection is broken.