### PR TITLE
Update Go compiler version in GHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.19
       -
         name: Set up Snapcraft
         run: |


### PR DESCRIPTION
The Go version in GHA was out of date and unsupported by the latest version of GoReleaser causing the last release to fail. This change simply updates the Go version to the latest version as of present.