### PR TITLE
Don't build for windows_arm64 (Fixes #84)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,9 @@ builds:
       - linux
       - windows
       - darwin
+    ignore:
+      - goos: windows
+        goarch: arm64
 archives:
   - replacements:
       darwin: Darwin


### PR DESCRIPTION
Looks like goreleaser started building for windows/arm64 which we don't support so lets skip it in the build matrix.

I believe this should do it.