### PR TITLE
Bump svix library version + add `app-portal` command

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -81,12 +81,12 @@ Example Schema:
 			if cmd.Flags().Changed(uidFlagName) {
 				uidFlag, err := cmd.Flags().GetString(uidFlagName)
 				printer.CheckErr(err)
-				app.Uid = &uidFlag
+				app.Uid.Set(&uidFlag)
 			}
 			if cmd.Flags().Changed(rateLimitFlagName) {
 				rateLimitFlag, err := cmd.Flags().GetInt32(rateLimitFlagName)
 				printer.CheckErr(err)
-				app.RateLimit = &rateLimitFlag
+				app.RateLimit.Set(&rateLimitFlag)
 			}
 
 			// validate args
@@ -166,12 +166,12 @@ Example Schema:
 			if cmd.Flags().Changed(uidFlagName) {
 				uidFlag, err := cmd.Flags().GetString(uidFlagName)
 				printer.CheckErr(err)
-				app.Uid = &uidFlag
+				app.Uid.Set(&uidFlag)
 			}
 			if cmd.Flags().Changed(rateLimitFlagName) {
 				rateLimitFlag, err := cmd.Flags().GetInt32(rateLimitFlagName)
 				printer.CheckErr(err)
-				app.RateLimit = &rateLimitFlag
+				app.RateLimit.Set(&rateLimitFlag)
 			}
 
 			svixClient := getSvixClientOrExit()

--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -98,12 +98,12 @@ Example Schema:
 			if cmd.Flags().Changed(filterTypesFlagName) {
 				filterTypesFlag, err := cmd.Flags().GetStringArray(filterTypesFlagName)
 				printer.CheckErr(err)
-				ep.FilterTypes = &filterTypesFlag
+				ep.FilterTypes = filterTypesFlag
 			}
 			if cmd.Flags().Changed(rateLimitFlagName) {
 				rateLimitFlag, err := cmd.Flags().GetInt32(rateLimitFlagName)
 				printer.CheckErr(err)
-				ep.RateLimit = &rateLimitFlag
+				ep.RateLimit.Set(&rateLimitFlag)
 			}
 			if cmd.Flags().Changed(disabledFlagName) {
 				disabledFlag, err := cmd.Flags().GetBool(disabledFlagName)
@@ -196,12 +196,12 @@ Example Schema:
 			if cmd.Flags().Changed(filterTypesFlagName) {
 				filterTypesFlag, err := cmd.Flags().GetStringArray(filterTypesFlagName)
 				printer.CheckErr(err)
-				ep.FilterTypes = &filterTypesFlag
+				ep.FilterTypes = filterTypesFlag
 			}
 			if cmd.Flags().Changed(rateLimitFlagName) {
 				rateLimitFlag, err := cmd.Flags().GetInt32(rateLimitFlagName)
 				printer.CheckErr(err)
-				ep.RateLimit = &rateLimitFlag
+				ep.RateLimit.Set(&rateLimitFlag)
 			}
 			if cmd.Flags().Changed(disabledFlagName) {
 				disabledFlag, err := cmd.Flags().GetBool(disabledFlagName)
@@ -336,7 +336,7 @@ Example Schema:
 				in, err = utils.ReadStdin()
 				printer.CheckErr(err)
 			}
-			var headersIn svix.EndpointHeadersIn
+			var headersIn svix.EndpointHeadersPatchIn
 			if len(in) > 0 {
 				err := json.Unmarshal(in, &headersIn)
 				printer.CheckErr(err)

--- a/cmd/message.go
+++ b/cmd/message.go
@@ -94,7 +94,7 @@ Example Schema:
 			if cmd.Flags().Changed(eventIdFlagName) {
 				eventIdFlag, err := cmd.Flags().GetString(eventIdFlagName)
 				printer.CheckErr(err)
-				msg.EventId = &eventIdFlag
+				msg.EventId.Set(&eventIdFlag)
 			}
 			if cmd.Flags().Changed(payloadFlagName) {
 				payloadFlag, err := cmd.Flags().GetString(payloadFlagName)

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,6 @@ require (
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/viper v1.10.0
-	github.com/svix/svix-webhooks v0.52.0
+	github.com/svix/svix-webhooks v0.75.0
 	github.com/tidwall/pretty v1.1.1
 )

--- a/go.sum
+++ b/go.sum
@@ -358,10 +358,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/svix/svix-webhooks v0.46.0 h1:nmp8PDRp2j7GPzVlnOQX2AxVk2+CS5T1aXKKyCjgbJo=
-github.com/svix/svix-webhooks v0.46.0/go.mod h1:vWwH7D6zMhF9pCLfgLlogcXGDmnGqIJeIT9AXorZTAQ=
-github.com/svix/svix-webhooks v0.52.0 h1:tBDDYSRCSlx0sGY4ciJBWwoKQ9sp8S1+EsYIy6ZGktg=
-github.com/svix/svix-webhooks v0.52.0/go.mod h1:vWwH7D6zMhF9pCLfgLlogcXGDmnGqIJeIT9AXorZTAQ=
+github.com/svix/svix-webhooks v0.75.0 h1:GH8myVTh6EDlVIHbyEXqs6bA8a/zSBH3JmZKRdD10WQ=
+github.com/svix/svix-webhooks v0.75.0/go.mod h1:vWwH7D6zMhF9pCLfgLlogcXGDmnGqIJeIT9AXorZTAQ=
 github.com/tidwall/pretty v1.1.1 h1:nt6/Ot5LtZnJCWwEFlelOixPo0xhPFsuZlKyOL3Xfnc=
 github.com/tidwall/pretty v1.1.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/inout/eventtypes.go
+++ b/inout/eventtypes.go
@@ -83,8 +83,8 @@ func GetAllEventTypes(sc *svix.Svix) ([]svix.EventTypeOut, error) {
 		for _, et := range out.Data {
 			eventTypes = append(eventTypes, svix.EventTypeOut(et))
 		}
-		if out.Iterator != nil {
-			iterator = out.Iterator
+		if out.Iterator.Get() != nil {
+			iterator = out.Iterator.Get()
 		}
 		done = out.Done
 	}


### PR DESCRIPTION
Bump to the latest library version (`0.75.0`)

This command uses the new `app-portal-access` endpoint instead of the deprecated `dashboard-access` one, supporting adding an optional request body.