### PR TITLE
Revert potentially erroneous change from #81

### DIFF
--- a/relay/relay.go
+++ b/relay/relay.go
@@ -130,11 +130,11 @@ func (c *Client) Listen(ctx context.Context) {
 			close(c.stopRead)
 			close(c.stopWrite)
 
-			c.wg.Wait()
-
 			if c.conn != nil {
 				c.conn.Close()
 			}
+
+			c.wg.Wait()
 		}
 	}
 }


### PR DESCRIPTION
It is suspected that #81 introduced a change causing a bug when communicating with Svix Play in relay mode. This change reverts #81 in order to eliminate that possibility.