### PR TITLE
Remove reconnection interval and prevent hanging

### DIFF
--- a/relay/relay.go
+++ b/relay/relay.go
@@ -38,7 +38,6 @@ type Client struct {
 	logging            bool
 
 	conn              *websocket.Conn
-	connResetInterval time.Duration
 	stopRead          chan struct{}
 	stopWrite         chan struct{}
 
@@ -88,7 +87,6 @@ func NewClient(token string, localURL *url.URL, opts *ClientOptions) *Client {
 			},
 			Timeout: defaultTimeout,
 		},
-		connResetInterval: time.Minute,
 		stopRead:          make(chan struct{}),
 		stopWrite:         make(chan struct{}),
 
@@ -126,17 +124,8 @@ func (c *Client) Listen(ctx context.Context) {
 			close(c.stopRead)
 			close(c.stopWrite)
 			c.wg.Wait()
-		case <-time.After(c.connResetInterval):
-			close(c.stopRead)
-			close(c.stopWrite)
-
-			if c.conn != nil {
-				c.conn.Close()
-			}
-
-			c.wg.Wait()
 		}
-	}
+    }
 }
 func (c *Client) close() {
 	if c.conn != nil {


### PR DESCRIPTION
Two bugs had been noticed, both with the automatic reconnection interval (where it would forcibly close the connection and reconnect every minute)  as the primary cause.

Upon reconnection, the text that prints when you first start the tool in `listen` mode would reprint causing the logs to be filled with the same connection message many times.

Additionally, there is an issue in the concurrency where, on seemingly random occasions, the program would hang after disconnecting but before reconnecting due to a closed channel.

Finally, changes were made to the channels to avoid potential hanging on channel closure.

By removing this interval and by preventing hanging the reconnection-based bugs should at the very least become much more rare.