### PR TITLE
add `--expunge` option to `event-type delete`

### DIFF
--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -105,10 +105,11 @@ Example Schema:
 				printer.CheckErr(err)
 				ep.Disabled = &disabledFlag
 			}
-			versionFlag, err := cmd.Flags().GetInt32(versionFlagName)
-			printer.CheckErr(err)
-			ep.Version = versionFlag
-
+			if cmd.Flags().Changed(versionFlagName) {
+				versionFlag, err := cmd.Flags().GetInt32(versionFlagName)
+				printer.CheckErr(err)
+				ep.Version.Set(&versionFlag)
+			}
 			svixClient := getSvixClientOrExit()
 			out, err := svixClient.Endpoint.Create(cmd.Context(), appID, &ep)
 			printer.CheckErr(err)
@@ -117,7 +118,7 @@ Example Schema:
 		},
 	}
 	create.Flags().String(urlFlagName, "", "")
-	create.Flags().Int32(versionFlagName, 1, "")
+	create.Flags().Int32(versionFlagName, 0, "")
 	create.Flags().StringArray(filterTypesFlagName, []string{}, "")
 	create.Flags().Int32(rateLimitFlagName, 0, "Rate Limit of the endpoint (optional)")
 	create.Flags().Bool(disabledFlagName, false, "")
@@ -189,7 +190,7 @@ Example Schema:
 			if cmd.Flags().Changed(versionFlagName) {
 				versionFlag, err := cmd.Flags().GetInt32(versionFlagName)
 				printer.CheckErr(err)
-				ep.Version = versionFlag
+				ep.Version.Set(&versionFlag)
 			}
 			if cmd.Flags().Changed(filterTypesFlagName) {
 				filterTypesFlag, err := cmd.Flags().GetStringArray(filterTypesFlagName)

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -152,15 +152,22 @@ Example Schema:
 			// parse args
 			eventID := args[0]
 
-			utils.Confirm(fmt.Sprintf("Are you sure you want to delete the the event with id: %s", eventID))
+			utils.Confirm(fmt.Sprintf("Are you sure you want to delete the event with id: %s", eventID))
 
 			svixClient := getSvixClientOrExit()
-			err := svixClient.EventType.Delete(cmd.Context(), eventID)
+			options := &svix.EventTypeDeleteOptions{}
+			expunge, _ := cmd.Flags().GetBool("expunge")
+			if cmd.Flags().Changed("expunge") {
+				options.Expunge = &expunge
+			}
+			err := svixClient.EventType.DeleteWithOptions(cmd.Context(), eventID, options)
 			printer.CheckErr(err)
 
 			fmt.Printf("Event Type \"%s\" Deleted!\n", eventID)
 		},
 	}
+
+	delete.Flags().Bool("expunge", false, "permanently delete instead of archiving")
 	etc.cmd.AddCommand(delete)
 
 	return etc

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,6 @@ require (
 	github.com/spf13/afero v1.6.0 // indirect
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/viper v1.10.0
-	github.com/svix/svix-webhooks v1.12.1-0.20230925234853-e39398a6349d
+	github.com/svix/svix-webhooks v1.12.1-0.20230926011735-7bc1d38200ec
 	github.com/tidwall/pretty v1.1.1
 )

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,6 @@ require (
 	github.com/spf13/afero v1.6.0 // indirect
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/viper v1.10.0
-	github.com/svix/svix-webhooks v1.7.0
+	github.com/svix/svix-webhooks v1.12.1-0.20230925234853-e39398a6349d
 	github.com/tidwall/pretty v1.1.1
 )

--- a/go.sum
+++ b/go.sum
@@ -362,6 +362,10 @@ github.com/svix/svix-webhooks v0.75.0 h1:GH8myVTh6EDlVIHbyEXqs6bA8a/zSBH3JmZKRdD
 github.com/svix/svix-webhooks v0.75.0/go.mod h1:vWwH7D6zMhF9pCLfgLlogcXGDmnGqIJeIT9AXorZTAQ=
 github.com/svix/svix-webhooks v1.7.0 h1:rfJ9yGc1h9odbdoNW8+dkO4ZdgajPYXvTdLqJsLBcIo=
 github.com/svix/svix-webhooks v1.7.0/go.mod h1:q3Z9c8NXqDRPZviI+zLMToAja+bjhTw929cMVhJirOI=
+github.com/svix/svix-webhooks v1.12.1-0.20230925233234-3ab7663b4d56 h1:PQ68xHJkoZ8Y0O283S+QRg9X6vbUyWKvuQHauLaaC3U=
+github.com/svix/svix-webhooks v1.12.1-0.20230925233234-3ab7663b4d56/go.mod h1:q3Z9c8NXqDRPZviI+zLMToAja+bjhTw929cMVhJirOI=
+github.com/svix/svix-webhooks v1.12.1-0.20230925234853-e39398a6349d h1:0EDWjQWi6yyBwekvXhMxbmM7M/llfGeYCeiUQvVfe8g=
+github.com/svix/svix-webhooks v1.12.1-0.20230925234853-e39398a6349d/go.mod h1:q3Z9c8NXqDRPZviI+zLMToAja+bjhTw929cMVhJirOI=
 github.com/tidwall/pretty v1.1.1 h1:nt6/Ot5LtZnJCWwEFlelOixPo0xhPFsuZlKyOL3Xfnc=
 github.com/tidwall/pretty v1.1.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/go.sum
+++ b/go.sum
@@ -366,6 +366,8 @@ github.com/svix/svix-webhooks v1.12.1-0.20230925233234-3ab7663b4d56 h1:PQ68xHJko
 github.com/svix/svix-webhooks v1.12.1-0.20230925233234-3ab7663b4d56/go.mod h1:q3Z9c8NXqDRPZviI+zLMToAja+bjhTw929cMVhJirOI=
 github.com/svix/svix-webhooks v1.12.1-0.20230925234853-e39398a6349d h1:0EDWjQWi6yyBwekvXhMxbmM7M/llfGeYCeiUQvVfe8g=
 github.com/svix/svix-webhooks v1.12.1-0.20230925234853-e39398a6349d/go.mod h1:q3Z9c8NXqDRPZviI+zLMToAja+bjhTw929cMVhJirOI=
+github.com/svix/svix-webhooks v1.12.1-0.20230926011735-7bc1d38200ec h1:q7YwrxoMXMHBhlrNqshcI+X+1zb5D8gNkNqsom3n+Dc=
+github.com/svix/svix-webhooks v1.12.1-0.20230926011735-7bc1d38200ec/go.mod h1:q3Z9c8NXqDRPZviI+zLMToAja+bjhTw929cMVhJirOI=
 github.com/tidwall/pretty v1.1.1 h1:nt6/Ot5LtZnJCWwEFlelOixPo0xhPFsuZlKyOL3Xfnc=
 github.com/tidwall/pretty v1.1.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=


### PR DESCRIPTION
Currently points at a pre-release branch for the svix client dependency. Need a release before this can be merged.

Some small fixups were required to update the version of the svix client lib. Specifically, endpoint version is now optional.

---


Verification for expunge:

```
$ ./svix-cli event-type list
{
  "data": [
    {
      "archived": false,
      "createdAt": "2023-09-27T00:47:39.841665Z",
      "description": "",
      "featureFlag": null,
      "name": "bar",
      "updatedAt": "2023-09-27T00:47:39.841678Z"
    },
    {
      "archived": false,
      "createdAt": "2023-09-27T00:47:35.572796Z",
      "description": "",
      "featureFlag": null,
      "name": "foo",
      "updatedAt": "2023-09-27T00:47:35.57282Z"
    }
  ],
  "done": true,
  "iterator": "foo",
  "prevIterator": "-bar"
}

$ ./svix-cli event-type delete foo
Are you sure you want to delete the event with id: foo: y
Event Type "foo" Deleted!

$ ./svix-cli event-type delete --expunge bar
Are you sure you want to delete the event with id: bar: y
Event Type "bar" Deleted!

$ ./svix-cli event-type list
{
  "data": [],
  "done": true,
  "iterator": null
}

$ ./svix-cli event-type list --include-archived
{
  "data": [
    {
      "archived": true,
      "createdAt": "2023-09-27T00:47:35.572796Z",
      "description": "",
      "featureFlag": null,
      "name": "foo",
      "updatedAt": "2023-09-27T00:48:10.556405Z"
    }
  ],
  "done": true,
  "iterator": "foo",
  "prevIterator": "-foo"
}
```

Verification for the endpoint version being optional now:

```
$ ./svix-cli endpoint create demo --data-url https://example.com/1
{
  "createdAt": "2023-09-27T01:05:42.270296Z",
  "description": "",
  "disabled": false,
  "id": "ep_2VxTTtr068YYOUNEzRTTCtzqhQk",
  "metadata": {},
  "rateLimit": null,
  "uid": null,
  "updatedAt": "2023-09-27T01:05:42.27031Z",
  "url": "https://example.com/1",
  "version": 1
}

$ ./svix-cli endpoint create demo --data-url https://example.com/22 --data-version 22
{
  "createdAt": "2023-09-27T01:07:32.855187Z",
  "description": "",
  "disabled": false,
  "id": "ep_2VxThnLAdOyT9RvlspOhHjoR8Cm",
  "metadata": {},
  "rateLimit": null,
  "uid": null,
  "updatedAt": "2023-09-27T01:07:32.8552Z",
  "url": "https://example.com/22",
  "version": 22
}
```