### PR TITLE
Fixup goreleaser config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,12 +18,17 @@ builds:
       - goos: windows
         goarch: arm64
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    format_overrides:
+      - goos: windows
+        format: zip
 checksum:
   name_template: 'checksums.txt'
 snapshot:
@@ -40,7 +45,7 @@ nfpms:
       - rpm
       - apk
 brews:
-  - tap:
+  - repository:
       owner: svix
       name: homebrew-svix
     commit_author:
@@ -51,15 +56,16 @@ brews:
     install: |
       bin.install "svix"
     caveats: "Thanks for installing the Svix CLI! If this is your first time using the CLI, checkout our docs at https://docs.svix.com."
-scoop:
-  bucket:
-    owner: svix
-    name: scoop-svix
-  commit_author:
-    name: svix-ci
-    email: support@svix.com
-  homepage: https://www.svix.com
-  description: Svix CLI utility
+scoops:
+  -
+    repository:
+      owner: svix
+      name: scoop-svix
+    commit_author:
+      name: svix-ci
+      email: support@svix.com
+    homepage: https://www.svix.com
+    description: Svix CLI utility
 snapcrafts:
   -
     name: svix


### PR DESCRIPTION
Looks like our config was outdated, and workflow used deprecated flags. These seem to have prevented the v0.20.0 release from happening.

Refs:
- <https://github.com/svix/svix-cli/actions/runs/5756141108/job/15605015680#step:5:19>
- <https://github.com/goreleaser/goreleaser/issues/3625>